### PR TITLE
Use C locale for ordering snapshot values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Imports:
     withr
 Remotes:
     rstudio/chromote,
-    r-lib/testthat
+    r-lib/testthat,
+    rstudio/shiny#3515
 Config/Needs/website:
     pkgdown,
     r-lib/testthat

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -100,6 +100,7 @@ sd2_getTestSnapshotUrl <- function(
     reqString("output", output),
     reqString("export", export),
     paste0("format=", format),
+    "sortC=1",
     sep = "&"
   )
 }


### PR DESCRIPTION
Related: https://github.com/rstudio/shiny/pull/3515


Opt in to sorting using the C locale. This will produce consistent output across platforms.