### PR TITLE
`allow_input_no_binding` -> `allow_no_input_binding`

### DIFF
--- a/R/app-driver-set-inputs.R
+++ b/R/app-driver-set-inputs.R
@@ -3,7 +3,7 @@ app_set_inputs <- function(
   ...,
   wait_ = TRUE,
   timeout_ = 3 * 1000,
-  allow_input_no_binding_ = FALSE,
+  allow_no_input_binding_ = FALSE,
   priority_ = c("input", "event")
 ) {
   ckm8_assert_app_driver(self, private)
@@ -14,7 +14,8 @@ app_set_inputs <- function(
   input_values <- lapply(inputs, function(value) {
     list(
       value = value,
-      allowInputNoBinding = allow_input_no_binding_,
+      # TODO-barret; rename
+      allowInputNoBinding = allow_no_input_binding_,
       priority = priority_
     )
   })

--- a/R/app-driver.R
+++ b/R/app-driver.R
@@ -387,7 +387,7 @@ AppDriver <- R6Class(# nolint
     #' @description Set input values.
     #' @param ... Name-value pairs, `component_name_1 = value_1, component_name_2 = value_2` etc.
     #'   Input with name `component_name_1` will be assigned value `value_1`.
-    #' @param allow_input_no_binding_ When setting the value of an input, allow
+    #' @param allow_no_input_binding_ When setting the value of an input, allow
     #'   it to set the value of an input even if that input does not have
     #'   an input binding.
     #' @param priority_ Sets the event priority. For expert use only: see
@@ -397,12 +397,12 @@ AppDriver <- R6Class(# nolint
       ...,
       wait_ = TRUE,
       timeout_ = 3 * 1000,
-      allow_input_no_binding_ = FALSE,
+      allow_no_input_binding_ = FALSE,
       priority_ = c("input", "event")
     ) {
       app_set_inputs(
         self, private, ..., wait_ = wait_, timeout_ = timeout_,
-        allow_input_no_binding_ = allow_input_no_binding_, priority_ = priority_
+        allow_no_input_binding_ = allow_no_input_binding_, priority_ = priority_
       )
     },
 

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -727,7 +727,7 @@ match_shinytest_expr <- function(expr_list, is_top_level, info_env) {
       matched_args <- match_shinytest_args("setInputs")
       matched_args_names <- names(matched_args)
       if ("allowInputNoBinding_" %in% matched_args_names) {
-        names(matched_args)[matched_args_names == "allowInputNoBinding_"] <- "allow_input_no_binding_"
+        names(matched_args)[matched_args_names == "allowInputNoBinding_"] <- "allow_no_input_binding_"
       }
       # Yell about removed functionality
       if (

--- a/R/record_test.R
+++ b/R/record_test.R
@@ -14,7 +14,7 @@
 #'   is provided, it will be saved in the test script.
 #' @param test_file Base file name of the \pkg{testthat} test file.
 #' @param edit_test If `TRUE`, the test file will be opened in an editor via [`file.edit()`] before executing.
-#' @param allow_input_no_binding This value controls if events without input
+#' @param allow_no_input_binding This value controls if events without input
 #' bindings are recorded.
 #'   * If `TRUE`, events without input bindings are recorded.
 #'   * If `FALSE`, events without input bindings are not recorded.
@@ -32,9 +32,7 @@ record_test <- function(
   shiny_args = list(),
   test_file = "test-shinytest2.R",
   edit_test = rlang::is_interactive() && rstudioapi::isAvailable(),
-  allow_input_no_binding = NULL, # new,
-  # TODO-barret; change to _this variable_ throughout package
-  # allow_no_input_binding = FALSE,
+  allow_no_input_binding = NULL,
   run_test = TRUE
 ) {
   ellipsis::check_dots_empty()
@@ -106,7 +104,7 @@ record_test <- function(
       shinytest2.seed         = seed,
       shinytest2.shiny.args   = shiny_args,
       shinytest2.test_file    = test_file,
-      shinytest2.allow_input_no_binding = allow_input_no_binding
+      shinytest2.allow_no_input_binding = allow_no_input_binding
     ),
     res <- shiny::runApp(system.file("internal", "recorder", package = "shinytest2"))
   )

--- a/inst/internal/recorder/app.R
+++ b/inst/internal/recorder/app.R
@@ -12,7 +12,7 @@ load_timeout  <- getOption("shinytest2.load.timeout")
 start_seed    <- getOption("shinytest2.seed")
 shiny_args    <- getOption("shinytest2.shiny.args")
 save_file     <- getOption("shinytest2.test_file")
-allow_input_no_binding <- getOption("shinytest2.allow_input_no_binding")
+allow_no_input_binding <- getOption("shinytest2.allow_no_input_binding")
 
 # If there are any reasons to not run a test, a message should be appended to
 # this vector.
@@ -406,7 +406,7 @@ shinyApp(
       n_console_std_lines <<- print_logs(level != "error", n = n_console_std_lines)
     })
 
-    allow_input_no_binding_react <- reactiveVal(allow_input_no_binding)
+    allow_no_input_binding_react <- reactiveVal(allow_no_input_binding)
 
     trim_testevents <- reactive({
       events <- input$testevents
@@ -425,7 +425,7 @@ shinyApp(
               to_remove[length(to_remove) + 1] <- i - 1
             },
             "inputEvent" = {
-              if (!isTRUE(allow_input_no_binding_react())) {
+              if (!isTRUE(allow_no_input_binding_react())) {
                 if (!curr_event$hasBinding && !prev_event$hasBinding) {
                   to_remove[length(to_remove) + 1] <- i
                 }
@@ -502,7 +502,7 @@ shinyApp(
 
                 code
               } else {
-                if (!event$hasBinding && !isTRUE(allow_input_no_binding_react())) {
+                if (!event$hasBinding && !isTRUE(allow_no_input_binding_react())) {
                   structure(
                     paste0(
                       "# Update unbound `input` value"
@@ -511,9 +511,9 @@ shinyApp(
                   )
                 } else {
                   args <- ""
-                  if (!event$hasBinding && isTRUE(allow_input_no_binding_react())) {
+                  if (!event$hasBinding && isTRUE(allow_no_input_binding_react())) {
                     # TODO-barret; test
-                    args <- paste0(args, ", allow_input_no_binding_ = TRUE")
+                    args <- paste0(args, ", allow_no_input_binding_ = TRUE")
                     if (identical(event$priority, "event")) {
                       args <- paste0(args, ', priority_ = "event"')
                     }
@@ -563,7 +563,7 @@ shinyApp(
     # If an unbound input value is updated, ask the user if the event should be recorded
     no_binding_obs <- list()
     no_binding_obs[[1]] <- observeEvent(trim_testevents(), {
-      if (!is.null(allow_input_no_binding_react())) {
+      if (!is.null(allow_no_input_binding_react())) {
         # Cancel the observers and return
         lapply(no_binding_obs, function(ob) { ob$destroy() })
         no_binding_obs <<- list()
@@ -579,7 +579,7 @@ shinyApp(
         observeEvent(
           input$inputs_no_binding_ignore,
           {
-            allow_input_no_binding_react(FALSE)
+            allow_no_input_binding_react(FALSE)
           },
           ignoreInit = TRUE
         )
@@ -587,7 +587,7 @@ shinyApp(
         observeEvent(
           input$inputs_no_binding_save,
           {
-            allow_input_no_binding_react(TRUE)
+            allow_no_input_binding_react(TRUE)
           },
           ignoreInit = TRUE
         )
@@ -608,8 +608,8 @@ shinyApp(
             tooltip(tagList(
               "To prevent this modal from being displayed, set the parameter", tags$br(),
               tags$ul(
-                tags$li(tags$code("record_test(allow_input_no_binding = TRUE)"), "to", tags$strong("record"), "these events."),
-                tags$li(tags$code("record_test(allow_input_no_binding = FALSE)"), "to", tags$strong("ignore"), "these events.")
+                tags$li(tags$code("record_test(allow_no_input_binding = TRUE)"), "to", tags$strong("record"), "these events."),
+                tags$li(tags$code("record_test(allow_no_input_binding = FALSE)"), "to", tags$strong("ignore"), "these events.")
               )
             ), placement = "left"),
             enable_tooltip_script(),

--- a/man/AppDriver.Rd
+++ b/man/AppDriver.Rd
@@ -655,7 +655,7 @@ Set input values.
   ...,
   wait_ = TRUE,
   timeout_ = 3 * 1000,
-  allow_input_no_binding_ = FALSE,
+  allow_no_input_binding_ = FALSE,
   priority_ = c("input", "event")
 )}\if{html}{\out{</div>}}
 }
@@ -670,7 +670,7 @@ Input with name \code{component_name_1} will be assigned value \code{value_1}.}
 
 \item{\code{timeout_}}{Amount of time to wait before giving up (milliseconds).}
 
-\item{\code{allow_input_no_binding_}}{When setting the value of an input, allow
+\item{\code{allow_no_input_binding_}}{When setting the value of an input, allow
 it to set the value of an input even if that input does not have
 an input binding.}
 

--- a/man/record_test.Rd
+++ b/man/record_test.Rd
@@ -13,7 +13,7 @@ record_test(
   shiny_args = list(),
   test_file = "test-shinytest2.R",
   edit_test = rlang::is_interactive() && rstudioapi::isAvailable(),
-  allow_input_no_binding = NULL,
+  allow_no_input_binding = NULL,
   run_test = TRUE
 )
 }
@@ -38,7 +38,7 @@ is provided, it will be saved in the test script.}
 
 \item{edit_test}{If \code{TRUE}, the test file will be opened in an editor via \code{\link[=file.edit]{file.edit()}} before executing.}
 
-\item{allow_input_no_binding}{This value controls if events without input
+\item{allow_no_input_binding}{This value controls if events without input
 bindings are recorded.
 \itemize{
 \item If \code{TRUE}, events without input bindings are recorded.

--- a/tests/testthat/test-migration-transformation.R
+++ b/tests/testthat/test-migration-transformation.R
@@ -67,10 +67,10 @@ expect_migration_error <- function(
 
 
 test_that("setInputs is converted", {
-  # expect_migration(
-  #   app$setInputs(x = 1, allowInputNoBinding_ = TRUE, y = 2),
-  #   app$set_inputs(x = 1, y = 2, allow_input_no_binding_ = TRUE)
-  # )
+  expect_migration(
+    app$setInputs(x = 1, allowInputNoBinding_ = TRUE, y = 2),
+    app$set_inputs(x = 1, y = 2, allow_no_input_binding_ = TRUE)
+  )
   expect_migration_error(
     app <- app$setInputs(x = 1, allowInputNoBinding_ = TRUE, y = 2),
     "Use `AppDriver$get_values()` directly."


### PR DESCRIPTION
Fixes https://github.com/rstudio/shinytest2/issues/81