### PR TITLE
Allow for console.log to handle number type

### DIFF
--- a/R/app-driver-get-log.R
+++ b/R/app-driver-get-log.R
@@ -3,6 +3,7 @@
 obj_to_string <- function(obj) {
   switch(obj$type,
     "string" = obj$value,
+    "number" = obj$value,
     "object" = {
       if (obj$subtype == "error") {
         obj$description
@@ -23,7 +24,8 @@ obj_to_string <- function(obj) {
           "*" = paste0("Structure:\n", structure),
           ">" = "Please report this new type with an example structure on https://github.com/rstudio/shinytest2/issues/new"
         ),
-        .frequency = "once"
+        .frequency = "once",
+        .frequency_id = obj$type
       )
       "(unknown)"
     }


### PR DESCRIPTION
* Fixed bug about `rlang::inform(.frequency=)` not having a `.frequency_id=` value. 
* Fixed bug of `number` type object being returned.
Reprex:

```r
app <- AppDriver$new("tests/testthat/apps/x")
app$execute_js("console.log('test 12', 345)")
app$get_log()
```