### PR TITLE
Safeguard the finalizer to notify when errors occur

### DIFF
--- a/R/app-driver-stop.R
+++ b/R/app-driver-stop.R
@@ -40,7 +40,7 @@ app_stop <- function(self, private) {
     } else {
       # Store the value to return later
       self$log_message("Getting Shiny process result")
-      tryCatc(
+      withCallingHandlers(
         private$shiny_proc_value <- private$shiny_process$get_result(),
         error = function(e) {
           self$log_message(paste0("Error getting Shiny process result!\n", conditionMessage(e)))

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -179,7 +179,7 @@ m__extract_runner_info <- function(app_info_env) {
     ))
   }
   # Store knowledge
-  tryCatch(
+  withCallingHandlers(
     testnames <- eval(testapp_args$testnames, envir = globalenv()),
     error = function(e) {
       rlang::abort("Could not use variables for `testnames` in `shinytest::testApp()`. Only atomic values are supported.")


### PR DESCRIPTION
... while trying to not prevent other actions from processing.

Fixes #116 

`AppDriver` finalizer is set in https://github.com/rstudio/shinytest2/blob/90a8fe26642d68e00c0a6145cf9a86c249b5b052/R/app-driver.R#L61-L63

From https://r6.r-lib.org/articles/Introduction.html#finalizers
> Finalizers are implemented using the [`reg.finalizer()`](https://rdrr.io/r/base/reg.finalizer.html) function, and they set `onexit=TRUE`, so that the finalizer will also be called when R exits.

---------------------------

Given #116 stems from https://github.com/rstudio/shinytest2/issues/108, it is hard to recover from a catastrophic failure. 

Hopefully these `withCallingHandlers()` will allow Shiny to shut down even if `chromote` fails to close.