### PR TITLE
Only use IDE viewer logic if on `server`. Otherwise use local chrome app

### DIFF
--- a/R/shiny-browser.R
+++ b/R/shiny-browser.R
@@ -1,5 +1,28 @@
 with_external_shiny_browser <- function(code) {
-  if (rstudio_is_available() && rstudioapi::versionInfo()$mode == "server") {
+  ## Logic
+  # if Chrome and not RStudio server, open with chrome
+  # else if RStudio is available, set RStudio prefs
+  # else (not Chrome and no RStudio), do nothing
+
+  is_rstudio_server <- rstudio_is_available() && rstudioapi::versionInfo()$mode == "server"
+
+  # Match the same Chromote object when initializing AppDriver's Chromote session
+  browser <- chromote::default_chromote_object()$get_browser()
+  if ((!is_rstudio_server) && inherits(browser, "Chrome")) {
+    # Local! (or not RStudio server!)
+    # Do not mess with the IDE options, instead just overwrite the
+    # shiny.launch.browser option
+
+    # If Chrome is locally available, use the local Chrome browser
+    browser_path <- shQuote(browser$get_path())
+    open_chrome <- function(url) {
+      browseURL(url, browser_path)
+    }
+    old_options <- options(shiny.launch.browser = open_chrome)
+    withr::defer({
+      options(old_options)
+    })
+  } else if (rstudio_is_available()) {
     # Server!
 
     # If in the IDE, force the url to open in the external browser
@@ -21,22 +44,6 @@ with_external_shiny_browser <- function(code) {
       old_option <- options(shiny.launch.browser = open_external)
       withr::defer({
         options(old_option)
-      })
-
-    }
-  } else {
-    # Local! (or Not RStudio!)
-    # Do not mess with the IDE options, instead just overwrite the shiny.launch.browser option
-    browser <- chromote::default_chromote_object()$get_browser()
-    if (inherits(browser, "Chrome")) {
-      # If Chrome is locally available, use the local Chrome browser
-      browser_path <- shQuote(browser$get_path())
-      open_chrome <- function(url) {
-        browseURL(url, browser_path)
-      }
-      old_options <- options(shiny.launch.browser = open_chrome)
-      withr::defer({
-        options(old_options)
       })
 
     }

--- a/R/shiny-browser.R
+++ b/R/shiny-browser.R
@@ -1,17 +1,7 @@
 with_external_shiny_browser <- function(code) {
-  browser <- chromote::default_chromote_object()$get_browser()
-  if (inherits(browser, "Chrome")) {
-    # If Chrome is locally available, use the local Chrome browser
-    browser_path <- shQuote(browser$get_path())
-    open_chrome <- function(url) {
-      browseURL(url, browser_path)
-    }
-    old_options <- options(shiny.launch.browser = open_chrome)
-    withr::defer({
-      options(old_options)
-    })
+  if (rstudio_is_available() && rstudioapi::versionInfo()$mode == "server") {
+    # Server!
 
-  } else if (rstudio_is_available()) {
     # If in the IDE, force the url to open in the external browser
     # Inspriation: https://github.com/rstudio/shinycoreci/blob/fa634714f14df8130cb60a6a1c8f07f53603a27b/R/test_in_ide.R#L98-L145
     if (rstudioapi::isAvailable("1.3.387")) {
@@ -31,6 +21,22 @@ with_external_shiny_browser <- function(code) {
       old_option <- options(shiny.launch.browser = open_external)
       withr::defer({
         options(old_option)
+      })
+
+    }
+  } else {
+    # Local! (or Not RStudio!)
+    # Do not mess with the IDE options, instead just overwrite the shiny.launch.browser option
+    browser <- chromote::default_chromote_object()$get_browser()
+    if (inherits(browser, "Chrome")) {
+      # If Chrome is locally available, use the local Chrome browser
+      browser_path <- shQuote(browser$get_path())
+      open_chrome <- function(url) {
+        browseURL(url, browser_path)
+      }
+      old_options <- options(shiny.launch.browser = open_chrome)
+      withr::defer({
+        options(old_options)
       })
 
     }

--- a/R/shiny-browser.R
+++ b/R/shiny-browser.R
@@ -28,7 +28,7 @@ with_external_shiny_browser <- function(code) {
       # Use the local Chrome browser path and shell escape it
       browser_path <- shQuote(browser$get_path())
       open_chrome <- function(url) {
-        browseURL(url, browser_path)
+        utils::browseURL(url, browser_path)
       }
       old_options <- options(shiny.launch.browser = open_chrome)
       withr::defer({

--- a/R/shiny-browser.R
+++ b/R/shiny-browser.R
@@ -18,6 +18,7 @@ with_external_shiny_browser <- function(code) {
 
   if (!is_rstudio_server) {
     # Match the same Chromote object when initializing AppDriver's Chromote session
+    # Use similar logic to `browse_url()`
     browser <- chromote::default_chromote_object()$get_browser()
     if (inherits(browser, "Chrome")) {
       # Has local Chrome browser!

--- a/R/shiny-browser.R
+++ b/R/shiny-browser.R
@@ -1,51 +1,62 @@
 with_external_shiny_browser <- function(code) {
   ## Logic
-  # if Chrome and not RStudio server, open with chrome
-  # else if RStudio is available, set RStudio prefs
-  # else (not Chrome and no RStudio), do nothing
 
-  is_rstudio_server <- rstudio_is_available() && rstudioapi::versionInfo()$mode == "server"
+  ## If Chrome is available, open in Chrome, except if RStudio server.
+  ## RStudio desktop can not open in: window, pane. Only external
+  ## RStudio server can open in any viewer location: window, pane, external.
+  ##   Do not adjust settings
 
-  # Match the same Chromote object when initializing AppDriver's Chromote session
-  browser <- chromote::default_chromote_object()$get_browser()
-  if ((!is_rstudio_server) && inherits(browser, "Chrome")) {
-    # Local! (or not RStudio server!)
-    # Do not mess with the IDE options, instead just overwrite the
-    # shiny.launch.browser option
+  ## Therefore,
+  ## If not RStudio server
+  ##   If Chrome, open in Chrome
+  ##   else If RStudio desktop, open in external
 
-    # If Chrome is locally available, use the local Chrome browser
-    browser_path <- shQuote(browser$get_path())
-    open_chrome <- function(url) {
-      browseURL(url, browser_path)
-    }
-    old_options <- options(shiny.launch.browser = open_chrome)
-    withr::defer({
-      options(old_options)
-    })
-  } else if (rstudio_is_available()) {
-    # Server!
+  is_avail <- rstudio_is_available()
+  rstudio_mode <- rstudioapi::versionInfo()$mode
+  is_rstudio_server <- is_avail && rstudio_mode == "server"
+  is_rstudio_desktop <- is_avail && rstudio_mode != "server"
 
-    # If in the IDE, force the url to open in the external browser
-    # Inspriation: https://github.com/rstudio/shinycoreci/blob/fa634714f14df8130cb60a6a1c8f07f53603a27b/R/test_in_ide.R#L98-L145
-    if (rstudioapi::isAvailable("1.3.387")) {
-      # See https://docs.rstudio.com/ide/server-pro/1.3.1073-1/session-user-settings.html
-      # user, none, pane, window, browser; Default is 'window'
-      shiny_viewer_type <- rstudioapi::readRStudioPreference("shiny_viewer_type", "window")
-      # Restore option
+  if (!is_rstudio_server) {
+    # Match the same Chromote object when initializing AppDriver's Chromote session
+    browser <- chromote::default_chromote_object()$get_browser()
+    if (inherits(browser, "Chrome")) {
+      # Has local Chrome browser!
+      # Do not mess with the IDE options, instead just overwrite the
+      # shiny.launch.browser option
+
+      # Use the local Chrome browser path and shell escape it
+      browser_path <- shQuote(browser$get_path())
+      open_chrome <- function(url) {
+        browseURL(url, browser_path)
+      }
+      old_options <- options(shiny.launch.browser = open_chrome)
       withr::defer({
-        rstudioapi::writeRStudioPreference("shiny_viewer_type", shiny_viewer_type)
+        options(old_options)
       })
+    } else if (is_rstudio_desktop) {
+      # Local RStudio desktop!
 
       # Force the url to open in the external browser
-      rstudioapi::writeRStudioPreference("shiny_viewer_type", "browser")
-    } else {
-      # RStudio, but early version
-      open_external <- get(".rs.invokeShinyWindowExternal", envir = as.environment("tools:rstudio"))
-      old_option <- options(shiny.launch.browser = open_external)
-      withr::defer({
-        options(old_option)
-      })
+      # Inspriation: https://github.com/rstudio/shinycoreci/blob/fa634714f14df8130cb60a6a1c8f07f53603a27b/R/test_in_ide.R#L98-L145
+      if (rstudioapi::isAvailable("1.3.387")) {
+        # See https://docs.rstudio.com/ide/server-pro/1.3.1073-1/session-user-settings.html
+        # user, none, pane, window, browser; Default is 'window'
+        shiny_viewer_type <- rstudioapi::readRStudioPreference("shiny_viewer_type", "window")
+        # Restore option
+        withr::defer({
+          rstudioapi::writeRStudioPreference("shiny_viewer_type", shiny_viewer_type)
+        })
 
+        # Force the url to open in the external browser
+        rstudioapi::writeRStudioPreference("shiny_viewer_type", "browser")
+      } else {
+        # RStudio, but early version
+        open_external <- get(".rs.invokeShinyWindowExternal", envir = as.environment("tools:rstudio"))
+        old_option <- options(shiny.launch.browser = open_external)
+        withr::defer({
+          options(old_option)
+        })
+      }
     }
   }
 

--- a/R/use.R
+++ b/R/use.R
@@ -62,7 +62,7 @@ use_shinytest2_package <- function(app_dir = ".", quiet = FALSE) {
     with_this_project({
       wrapper <-
         if (quiet) function(...) {
-          capture.output(..., type = "message")
+          utils::capture.output(..., type = "message")
         } else {
           force
         }

--- a/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/test-shinytest2.R
@@ -10,7 +10,7 @@ test_that("testthat is a depends package", {
 
 test_that("AppDriver can print while working with `missing_arg()` values", {
   expect_error(
-    capture.output({
+    utils::capture.output({
       print(AppDriver$new(test_path("apps/x")))
     }),
     NA


### PR DESCRIPTION
Followup to #115 and related to https://github.com/rstudio/chromote/pull/73

Tested on Colorado server. On Colorado workbench, I can view the recorder in any viewer location.

Locally, it opens in Chrome (my non-default browser).
