### PR TITLE
Use `httr::parse_url()` and `httr::build_url()` to support complicated urls

### DIFF
--- a/R/R6-helper.R
+++ b/R/R6-helper.R
@@ -46,25 +46,18 @@ Url <- R6Class( # nolint
       private$url
     },
     set = function(url) {
-      res <- parse_url(url)
+      res <- httr::parse_url(url)
 
-      if (nzchar(res$port)) {
+      checkmate::assert_subset(res$scheme, c("http", "https"), .var.name = "url scheme")
+
+      if (!is.null(res$port)) {
         res$port <- as.integer(res$port)
-        ckm8_assert_single_integer(res$port, .var.name = "port")
-      } else {
-        res$port <- NULL
+        ckm8_assert_single_integer(res$port, .var.name = "url port")
       }
 
-      res$path <- if (nzchar(res$path)) res$path else "/"
+      ckm8_assert_single_string(res$hostname, .var.name = "url hostname")
 
-      ckm8_assert_single_string(res$host)
-      ckm8_assert_single_url(res$path)
-
-      private$url <- paste0( # nolint
-        res$protocol, "://", res$host,
-        if (!is.null(res$port)) paste0(":", res$port),
-        res$path
-      )
+      private$url <- httr::build_url(res)
 
       invisible(self)
     }

--- a/R/httr.R
+++ b/R/httr.R
@@ -1,12 +1,5 @@
 httr_get <- function(url) {
   pieces <- httr::parse_url(url)
-
-  # cat("Url parts: \n")
-  # utils::str(list(
-  #   url = url,
-  #   pieces = pieces
-  # ))
-
   # Only check if no basic auth is being used
   if (is.null(pieces$username) && is.null(pieces$password)) {
     if (!pingr::is_up(pieces$hostname, pieces$port)) {

--- a/R/httr.R
+++ b/R/httr.R
@@ -7,8 +7,11 @@ httr_get <- function(url) {
   #   pieces = pieces
   # ))
 
-  if (!pingr::is_up(pieces$hostname, pieces$port)) {
-    abort("Shiny app is no longer running")
+  # Only check if no basic auth is being used
+  if (is.null(pieces$username) && is.null(pieces$password)) {
+    if (!pingr::is_up(pieces$hostname, pieces$port)) {
+      abort("Shiny app is no longer running")
+    }
   }
 
   withCallingHandlers(

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,9 +9,6 @@ ckm8_assert_single_integer <- function(x, ..., len = 1, any.missing = FALSE, .va
 ckm8_assert_single_number <- function(x, ..., .var.name = checkmate::vname(x)) {
   checkmate::assert_number(x, .var.name = .var.name, ...)
 }
-ckm8_assert_single_url <- function(x, .var.name = checkmate::vname(x)) {
-  checkmate::assert_character(x, pattern = "^/", len = 1, any.missing = FALSE, .var.name = .var.name)
-}
 ckm8_assert_app_driver <- function(self, private, self.var.name = checkmate::vname(self), private.var.name = checkmate::vname(private)) {
   checkmate::assert_r6(self, "AppDriver", .var.name = self.var.name)
   checkmate::assert_environment(private, .var.name = private.var.name)
@@ -51,54 +48,6 @@ read_utf8 <- function(file) {
 # write text as UTF-8
 write_utf8 <- function(text, ...) {
   writeBin(charToRaw(enc2utf8(text)), ...)
-}
-
-
-parse_url <- function(url) {
-  res <- regexpr("^(?<protocol>https?)://(?<host>[^:/]+)(:(?<port>\\d+))?(?<path>/.*)?$", url, perl = TRUE)
-
-  if (res == -1) abort(paste0(url, " is not a valid URL."))
-
-  start  <- attr(res, "capture.start",  exact = TRUE)[1, ]
-  length <- attr(res, "capture.length", exact = TRUE)[1, ]
-
-  get_piece <- function(n) {
-    if (start[[n]] == 0) return("")
-
-    substring(url, start[[n]], start[[n]] + length[[n]] - 1)
-  }
-
-  list(
-    protocol = get_piece("protocol"),
-    host     = get_piece("host"),
-    port     = get_piece("port"),
-    path     = get_piece("path")
-  )
-}
-is_rmd <- function(path) {
-  if (utils::file_test("-d", path)) {
-    FALSE
-  } else if (grepl("\\.Rmd", path, ignore.case = TRUE)) {
-    TRUE
-  } else {
-    FALSE
-  }
-}
-
-is_app <- function(path) {
-  tryCatch(
-    {
-      shiny::shinyAppDir(path)
-      TRUE
-    },
-    # shiny::shinyAppDir() throws a classed exception when path isn't a
-    # directory, or it doesn't contain an app.R (or server.R) file
-    # https://github.com/rstudio/shiny/blob/a60406a/R/shinyapp.R#L116-L119
-    invalidShinyAppDir = function(x) FALSE,
-    # If we get some other error, it's probably from sourcing
-    # of the app file(s), so throw that error now
-    error = function(x) abort(conditionMessage(x))
-  )
 }
 
 

--- a/tests/testthat/test-url.R
+++ b/tests/testthat/test-url.R
@@ -1,0 +1,27 @@
+
+test_that("Url Class behaves as expected", {
+
+  expect_url <- function(url, expected_url) {
+    expect_equal(Url$new()$set(url)$get(), expected_url)
+  }
+
+  expect_url("http://a.b.com", "http://a.b.com/")
+  expect_url("https://a.b.com/", "https://a.b.com/")
+  expect_url("http://a.b.com:1020", "http://a.b.com:1020/")
+  expect_url("http://a.b.com:1020/", "http://a.b.com:1020/")
+  expect_url("http://a.b.com:1020/abc", "http://a.b.com:1020/abc")
+  expect_url("http://a.b.com:1020/abc/", "http://a.b.com:1020/abc/")
+  expect_url("http://a.b.com/abc/", "http://a.b.com/abc/")
+  expect_url("http://user@a.b.com/", "http://user@a.b.com/")
+  expect_url("http://user:pass@a.b.com/", "http://user:pass@a.b.com/")
+
+  # Malformed URLs, or non-http/https protocol
+  expect_url_error <- function(url, ...) {
+    expect_error(Url$new()$set(url), ...)
+  }
+  expect_url_error("http:/a.b.com/", "url hostname")
+  expect_warning(
+    expect_url_error("http://a.b.com:12ab/", "url port")
+  )
+  expect_url_error("ftp://a.b.com/", "url scheme")
+})


### PR DESCRIPTION
Related: https://github.com/rstudio/shinytest/pull/427
Fixes #84

cc @bersbersbers
