### PR TITLE
Allow `test_app()` to change locations depending on execution directory

### DIFF
--- a/R/test-app.R
+++ b/R/test-app.R
@@ -6,33 +6,56 @@ NULL
 #'
 #' Example usage:
 #' ```r
-#' # Interactive usage
-#' path_to_app <- "."
+#' ## Interactive usage
+#' # Test Shiny app in current working directory
+#' shinytest2::test_app()
+#' # Test Shiny app in another directory
+#' path_to_app <- "path/to/app"
 #' shinytest2::test_app(path_to_app)
 #'
-#' # File: ./tests/testthat.R
+#' ## File: ./tests/testthat.R
+#' # Will find Shiny app in "../"
 #' shinytest2::test_app()
 #'
-#' # File: ./tests/testthat/test-shinytest2.R
+#' ## File: ./tests/testthat/test-shinytest2.R
+#' # Test a shiny application within your own {testthat} code
 #' test_that("Testing an external app", {
 #'   shinytest2::test_app(path_to_app)
 #' })
 #' ```
 #'
-#' @param app_dir The base directory for the Shiny application
+#' @param app_dir The base directory for the Shiny application.
+#'   * If `app_dir` is missing and `test_app()` is called within the
+#'     `./tests/testthat.R` file, the parent directory (`"../"`) is used.
+#'   * Otherwise, the default path of `"."` is used.
 #' @param env Use the shiny application's environment after sourcing the R folder
 #' @param ... Parameters passed to [`testthat::test_dir()`]
 #' @export
 # Inspiration from https://github.com/rstudio/shiny/blob/a8c14dab9623c984a66fcd4824d8d448afb151e7/inst/app_template/tests/testthat.R
 test_app <- function(
-  app_dir = "../",
+  app_dir = missing_arg(),
   # Run in the app's environment containing all support methods.
   env = shiny::loadSupport(app_dir),
   ...
 ) {
   library(shinytest2)
-  # force variables before testing starts / paths change
-  list2(app_dir, env, ...)
+
+  app_dir <- rlang::maybe_missing(app_dir, {
+    cur_path <- fs::path_abs(".")
+    cur_folder <- fs::path_file(cur_path)
+    sibling_folders <- fs::path_file(fs::dir_ls(cur_path))
+    if (
+      length(cur_folder) == 1 &&
+      cur_folder == "tests" &&
+      "testthat" %in% sibling_folders
+    ) {
+      "../"
+    # } else if ("tests" %in% sibling_folders) {
+    #   "."
+    } else {
+      "."
+    }
+  })
 
   app_dir <- app_dir_value(app_dir)
 

--- a/man/test_app.Rd
+++ b/man/test_app.Rd
@@ -4,26 +4,40 @@
 \alias{test_app}
 \title{Test shiny application with testthat}
 \usage{
-test_app(app_dir = "../", env = shiny::loadSupport(app_dir), ...)
+test_app(app_dir = missing_arg(), env = shiny::loadSupport(app_dir), ...)
 }
 \arguments{
-\item{app_dir}{The base directory for the Shiny application}
+\item{app_dir}{The base directory for the Shiny application.
+\itemize{
+\item If \code{app_dir} is missing and \code{test_app()} is called within the
+\code{./tests/testthat.R} file, the parent directory (\code{"../"}) is used.
+\item Otherwise, the default path of \code{"."} is used.
+}}
 
 \item{env}{Use the shiny application's environment after sourcing the R folder}
 
 \item{...}{Parameters passed to \code{\link[testthat:test_dir]{testthat::test_dir()}}}
 }
 \description{
-Example usage:\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Interactive usage
-path_to_app <- "."
+Example usage:\if{html}{\out{<div class="sourceCode r">}}\preformatted{## Interactive usage
+# Test Shiny app in current working directory
+shinytest2::test_app()
+# Test Shiny app in another directory
+path_to_app <- "path/to/app"
 shinytest2::test_app(path_to_app)
 }\if{html}{\out{</div>}}
 }
-\section{File: ./tests/testthat.R}{
+\details{
+\subsection{File: ./tests/testthat.R}{
+}
+}
+\section{Will find Shiny app in "../"}{
 shinytest2::test_app()
+\subsection{File: ./tests/testthat/test-shinytest2.R}{
+}
 }
 
-\section{File: ./tests/testthat/test-shinytest2.R}{
+\section{Test a shiny application within your own {testthat} code}{
 test_that("Testing an external app", {
 shinytest2::test_app(path_to_app)
 })\preformatted{}


### PR DESCRIPTION
Fixes #133 

* If currently in `./tests/` folder and `./tests/testthat/` exists, use `app_dir = "../"`; (Ex: usage in `./tests/testthat.R`)
* Else set `app_dir = "."` for `test_app(app_dir=)` ; (Common interactive case)
