### PR TITLE
Temp commit changes to look at other ideas

### DIFF
--- a/R/test-app.R
+++ b/R/test-app.R
@@ -128,18 +128,24 @@ test_app <- function(
     }
   }
 
-  is_currently_testing <- testthat::is_testing()
-
+  # is_currently_testing <- testthat::is_testing()
   ret <- testthat::test_dir(
     path = fs::path(app_dir, "tests", "testthat"),
+    # # Super verbose even though it is compact
+    # reporter = testthat::default_compact_reporter(),
+
+    # # Keeps track of all tests
+    # # Deletes "unused snapshots", which is bad
+    # reporter = testthat::get_reporter(),
+
     ...
   )
 
-  # If we are testing and no error has been thrown,
-  # then perform an expectation so that the testing chunk passes
-  if (is_currently_testing) {
-    testthat::expect_equal(TRUE, TRUE)
-  }
+  # # If we are testing and no error has been thrown,
+  # # then perform an expectation so that the testing chunk passes
+  # if (is_currently_testing) {
+  #   testthat::expect_equal(TRUE, TRUE)
+  # }
 
   invisible(ret)
 }

--- a/tests/testthat/test-apps.R
+++ b/tests/testthat/test-apps.R
@@ -9,10 +9,12 @@ lapply(dirs, function(shiny_app_dir) {
     rlang::inform(shiny_app_dir)
     test_that(paste0("All apps pass their tests - ", shiny_app_dir), {
       # Test that `test_app()` is performing an expectation in a testing setting
-      expect_success({
+      # expect_success({
         # Given only testthat tests are used
         test_app(shiny_app_dir)
-      })
+      # })
+
+      expect_equal(TRUE, TRUE)
 
       # # If non-testthat tests are used, this code should be used instead:
       # expect_error(


### PR DESCRIPTION
Related: #189 

cc @gadenbuie 

Using `reporter = testthat::get_reporter()`, _inner_ tests are accounted for but snapshots are deleted prematurely:

```
✔ | F W S  OK | Context
✔ |     1   0 | aaa
───────
Skip (test-aaa.R:5:3): Chromote loads
Reason: Not on CI
───────
⠏ |         0 | apps                                                                                                                                                                              apps/download
v | F W S  OK | Context
v |        16 | app-download [19.7s]

== Results ===
Duration: 19.8 s

-- Skipped tests  ---
* Not on CI (1)

[ FAIL 0 | WARN 0 | SKIP 1 | PASS 16 ]
Deleting unused snapshots:
* shiny-app-driver/app-001.json
* shiny-app-driver/app-dir-001.json
⠦ |        17 | app-download
```

When not passing through the `reporter`, the _inner_ tests are not accounted for:

```
✔ | F W S  OK | Context
✔ |     1   0 | aaa
───────
Skip (test-aaa.R:5:3): Chromote loads
Reason: Not on CI
───────
⠏ |         0 | apps                                                                                                                                                                              apps/download
v | F W S  OK | Context

/ |         0 | app-download
- |         1 | app-download
| |         3 | app-download
- |         5 | app-download
| |         7 | app-download
- |         9 | app-download
| |        11 | app-download
- |        13 | app-download
v |        16 | app-download [19.3s]

== Results ===
Duration: 19.3 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 16 ]
⠋ |         1 | apps
```