### PR TITLE
Exploring the possibility of auto-closing the test app window after exiting the test

### DIFF
--- a/inst/internal/recorder/app.R
+++ b/inst/internal/recorder/app.R
@@ -706,6 +706,8 @@ shinyApp(
     observeEvent(input$exit_save, {
       req(save_enabled())
 
+      session$sendCustomMessage("close_window", TRUE)
+      
       stopApp({
         seed <- as.integer(input$seed)
         if (is.null(seed) || is.na(seed)) {
@@ -769,6 +771,7 @@ shinyApp(
       })
     })
     observeEvent(input$exit_nosave, {
+      session$sendCustomMessage("close_window", TRUE)
       stopApp({
         invisible(list(
           test_file = NULL

--- a/inst/internal/recorder/www/inject-recorder.js
+++ b/inst/internal/recorder/www/inject-recorder.js
@@ -150,6 +150,10 @@ window.recorder = (function() {
             $("#exit_save").toggleClass("disabled", !message);
         });
 
+        Shiny.addCustomMessageHandler("close_window", function(message) {
+            window.close();
+        });
+
     });
 
 


### PR DESCRIPTION
@schloerke when we spoke earlier today, I mentioned it would be nice to have some sort of "Test recorded successfully" message when clicking the exit button, instead of just the gray "disconnected/error" screen. IIRC you mentioned it would be nice to auto close the window.

This is just a POC, but perhaps something like this would work fine? I tested it on my RStudio+chrome combo on windows and it seemed to work.