### PR TITLE
Don't try to convert numeric datetime values to Date objects. Closes #228

### DIFF
--- a/inst/internal/js/shiny-tracer.js
+++ b/inst/internal/js/shiny-tracer.js
@@ -104,15 +104,7 @@ window.shinytest2 = (function() {
 
             "shiny.sliderInput": function(el, value) {
                 function update_date_string(x) {
-                  if (
-                    (
-                      typeof(x) === "string" &&
-                      /\d\d\d\d-\d\d-\d\d/.test(x)
-                    ) ||
-                    (
-                      typeof(x) === "number"
-                    )
-                  ) {
+                  if (typeof(x) === "string" && /\d\d\d\d-\d\d-\d\d/.test(x)) {
                     return new Date(x).getTime();
                   } else {
                     return x;


### PR DESCRIPTION
Closes #228.

This switches back to the old behavior of _not_ trying to convert numeric datetime values to `Date` objects in JavaScript. The problem with the current code (before this PR) is that it converts all numbers to datetimes, even if they're supposed to be regular numbers.