### PR TITLE
Change exec directory to app directory before starting background R process

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
     line_length_linter = NULL,
+    indentation_linter = NULL,
     commented_code_linter = NULL,
     cyclocomp_linter = NULL
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinytest2
 Title: Testing for Shiny Applications
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R:
     c(
         person("Barret", "Schloerke", role = c("cre", "aut"), email = "barret@rstudio.com", comment = c(ORCID = "0000-0001-9986-114X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # shinytest2 (development version)
 
+* Set the directory to the Shiny App directory before starting the background R process. This allows for local `.Rprofile` and `.Renviron` files to be found naturally. (#275)
+
+
 # shinytest2 0.2.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# shinytest2 (development version)
+
 # shinytest2 0.2.0
 
 ## Breaking changes

--- a/R/app-driver-start.R
+++ b/R/app-driver-start.R
@@ -17,6 +17,8 @@ app_start_shiny <- function(
   p <- local({
     # https://github.com/r-lib/testthat/issues/603
     withr::local_envvar(c("R_TESTS" = NA))
+    # Load the app's .Rprofile / .Renviron if possible
+    withr::local_dir(self$get_dir())
 
     callr::r_bg(
       stdout = sprintf(tempfile_format, "shiny-stdout"),

--- a/R/app-driver-start.R
+++ b/R/app-driver-start.R
@@ -14,9 +14,23 @@ app_start_shiny <- function(
   # the RNG kind should inherit from the parent process
   rng_kind <- RNGkind()
 
-  p <- withr::with_envvar(
-    c("R_TESTS" = NA),
+  p <- local({
+    # https://github.com/r-lib/testthat/issues/603
+    withr::local_envvar(c("R_TESTS" = NA))
+
     callr::r_bg(
+      stdout = sprintf(tempfile_format, "shiny-stdout"),
+      stderr = sprintf(tempfile_format, "shiny-stderr"),
+      supervise = TRUE,
+      args = list(
+        app_dir = self$get_dir(),
+        shiny_args = shiny_args,
+        has_rmd = app_dir_has_rmd(self, private),
+        seed = seed,
+        rng_kind = rng_kind,
+        render_args = render_args,
+        options = options
+      ),
       function(app_dir, shiny_args, has_rmd, seed, rng_kind, render_args, options) {
 
         if (!is.null(seed)) {
@@ -49,21 +63,10 @@ app_start_shiny <- function(
           # Normal shiny app
           do.call(shiny::runApp, c(app_dir, shiny_args))
         }
-      },
-      args = list(
-        app_dir = self$get_dir(),
-        shiny_args = shiny_args,
-        has_rmd = app_dir_has_rmd(self, private),
-        seed = seed,
-        rng_kind = rng_kind,
-        render_args = render_args,
-        options = options
-      ),
-      stdout = sprintf(tempfile_format, "shiny-stdout"),
-      stderr = sprintf(tempfile_format, "shiny-stderr"),
-      supervise = TRUE
+      }
     )
-  )
+  })
+
   private$shiny_process <- p # nolint
 
   "!DEBUG waiting for shiny to start"

--- a/tests/testthat/apps/dir-profile/.Rprofile
+++ b/tests/testthat/apps/dir-profile/.Rprofile
@@ -1,0 +1,1 @@
+shinytest2_profile_value <- "found!"

--- a/tests/testthat/apps/dir-profile/app.R
+++ b/tests/testthat/apps/dir-profile/app.R
@@ -1,0 +1,13 @@
+library(shiny)
+
+txt_val <- get0("shinytest2_profile_value", ifnotfound = "Not found! 😔😭")
+
+ui <- fluidPage(
+  "This app must be run in a clean R session that is started in the same directory as the app.R file.",
+  textOutput("txt"),
+)
+server <- function(input, output, session) {
+  output$txt <- renderText(txt_val)
+}
+
+shinyApp(ui, server)

--- a/tests/testthat/apps/dir-profile/tests/testthat.R
+++ b/tests/testthat/apps/dir-profile/tests/testthat.R
@@ -1,0 +1,1 @@
+shinytest2::test_app()

--- a/tests/testthat/apps/dir-profile/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/apps/dir-profile/tests/testthat/setup-shinytest2.R
@@ -1,0 +1,2 @@
+# Load application support files into testing environment
+shinytest2::load_app_env()

--- a/tests/testthat/apps/dir-profile/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/apps/dir-profile/tests/testthat/test-shinytest2.R
@@ -4,7 +4,7 @@ test_that("{shinytest2} recording: dir-profile", {
   app <- AppDriver$new(name = "dir-profile", height = 1133, width = 1282)
 
   expect_equal(
-    app$get_value(output="txt"),
+    app$get_value(output = "txt"),
     "found!"
   )
 })

--- a/tests/testthat/apps/dir-profile/tests/testthat/test-shinytest2.R
+++ b/tests/testthat/apps/dir-profile/tests/testthat/test-shinytest2.R
@@ -1,0 +1,10 @@
+library(shinytest2)
+
+test_that("{shinytest2} recording: dir-profile", {
+  app <- AppDriver$new(name = "dir-profile", height = 1133, width = 1282)
+
+  expect_equal(
+    app$get_value(output="txt"),
+    "found!"
+  )
+})


### PR DESCRIPTION
Related: https://github.com/rstudio/shinytest2/issues/271#issuecomment-1303514075

Allows for the app's local .Rprofile / .Renviron files to be found naturally.

cc @yogat3ch