### PR TITLE
`compare_screenshot_threshold()` should not error from `screenshot_max_difference()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Set the directory to the Shiny App directory before starting the background R process. This allows for local `.Rprofile` and `.Renviron` files to be found naturally. (#275)
 
+* Fixed bug where `compare_screenshot_threshold()` did not safe guard against errors thrown by `screenshot_max_difference()`. (#276)
+
 
 # shinytest2 0.2.0
 

--- a/R/compare-screenshot-threshold.R
+++ b/R/compare-screenshot-threshold.R
@@ -147,11 +147,20 @@ compare_screenshot_threshold <- function(
     len = 1
   )
 
-  conv_max_value <- screenshot_max_difference(
-    old = old,
-    new = new,
-    kernel_size = kernel_size
+  conv_max_value <- try(
+    # If errors occur, this means the images are very different.
+    # No need to replay the error message
+    silent = TRUE,
+    screenshot_max_difference(
+      old = old,
+      new = new,
+      kernel_size = kernel_size
+    )
   )
+  if (inherits(conv_max_value, "try-error")) {
+    # If the screenshot_max_difference calculation, the images are not the same
+    return(FALSE)
+  }
 
   ret <- conv_max_value < threshold
 

--- a/tests/testthat/test-image-diff.R
+++ b/tests/testthat/test-image-diff.R
@@ -81,3 +81,17 @@ test_that("kernel size makes a difference", {
   expect_gt(big_max_diff, 44)
   expect_lt(big_max_diff, 50)
 })
+
+
+test_that("Errors in screenshot_max_difference do not cause errors in compare_screenshot_threshold", {
+  expect_silent({
+    comp_val <-
+      compare_screenshot_threshold(
+        slider_old,
+        bookmark_old,
+        threshold = 5
+      )
+  })
+  expect_false(comp_val)
+
+})


### PR DESCRIPTION
If `screenshot_max_difference()` throws and error, `compare_screenshot_threshold()` should return `FALSE` (to signify the images are different).