### PR TITLE
Fix: missing backtick in param docs

### DIFF
--- a/R/app-driver.R
+++ b/R/app-driver.R
@@ -1064,7 +1064,7 @@ AppDriver <- R6Class( # nolint
     #' images byte-by-byte.
     #' @param threshold Parameter supplied to [`compare_screenshot_threshold()`]
     #' when using the default `compare` method. If the value of `threshold` is
-    #' NULL`, [`compare_screenshot_threshold()`] will act like
+    #' `NULL`, [`compare_screenshot_threshold()`] will act like
     #' [`testthat::compare_file_binary`]. However, if `threshold` is a positive number,
     #' it will be compared against the largest convolution value found if the
     #' two images fail a [`testthat::compare_file_binary`] comparison.

--- a/man/AppDriver.Rd
+++ b/man/AppDriver.Rd
@@ -2200,7 +2200,10 @@ recommended to use other expectation methods.
 
 \item{\code{threshold}}{Parameter supplied to \code{\link[=compare_screenshot_threshold]{compare_screenshot_threshold()}}
 when using the default \code{compare} method. If the value of \code{threshold} is
-NULL\verb{, [}compare_screenshot_threshold()\verb{] will act like [}testthat::compare_file_binary\verb{]. However, if }threshold\verb{ is a positive number, it will be compared against the largest convolution value found if the two images fail a [}testthat::compare_file_binary`] comparison.
+\code{NULL}, \code{\link[=compare_screenshot_threshold]{compare_screenshot_threshold()}} will act like
+\code{\link[testthat:expect_snapshot_file]{testthat::compare_file_binary}}. However, if \code{threshold} is a positive number,
+it will be compared against the largest convolution value found if the
+two images fail a \code{\link[testthat:expect_snapshot_file]{testthat::compare_file_binary}} comparison.
 
 Which value should I use? Threshold values values below 5 help deter
 false-positive screenshot comparisons (such as inconsistent rounded


### PR DESCRIPTION
Fixes the odd formatting caused by a missing backtick here: https://rstudio.github.io/shinytest2/reference/AppDriver.html#method-expect-screenshot-

![image](https://user-images.githubusercontent.com/5420529/236845890-7819cd56-f63b-4dfa-abb8-5c4de46bc49f.png)
