### PR TITLE
Change device scale factor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # shinytest2 (development version)
 
+## Breaking changes
+
+* `AppDriver$get_screenshot()`/`AppDriver$expect_screenshot()` now default an underlying `deviceScaleFactor` option to 0 instead of 1. This ensures that image sizes are more consistent across devices. To revert to prior behavior, provide `screenshot_args = list(scale = 1)` to `get_screenshot()`/`expect_screenshot()`  (#350).
+
 # shinytest2 0.3.0
 
 ## Breaking changes

--- a/R/chromote-methods.R
+++ b/R/chromote-methods.R
@@ -200,7 +200,7 @@ chromote_wait_for_condition <- function(
 
 
 
-chromote_set_device_metrics <- function(chromote_session, ..., width = NULL, height = NULL, device_scale_factor = 1, mobile = FALSE) {
+chromote_set_device_metrics <- function(chromote_session, ..., width = NULL, height = NULL, device_scale_factor = 0, mobile = FALSE) {
   assert_chromote_session(chromote_session)
   ellipsis::check_dots_empty()
 

--- a/R/chromote-methods.R
+++ b/R/chromote-methods.R
@@ -200,15 +200,15 @@ chromote_wait_for_condition <- function(
 
 
 
-chromote_set_device_metrics <- function(chromote_session, ..., width = NULL, height = NULL, device_scale_factor = 0, mobile = FALSE) {
+chromote_set_device_metrics <- function(chromote_session, ..., width = NULL, height = NULL) {
   assert_chromote_session(chromote_session)
   ellipsis::check_dots_empty()
 
   chromote_session$Emulation$setDeviceMetricsOverride(
     width = width,
     height = height,
-    deviceScaleFactor = device_scale_factor,
-    mobile = mobile
+    deviceScaleFactor = 0,
+    mobile = FALSE
   )
 }
 

--- a/tests/testthat/test-app-screenshot-size.R
+++ b/tests/testthat/test-app-screenshot-size.R
@@ -2,6 +2,8 @@ library(shiny)
 
 
 test_that("images are captured via expect_values", {
+  skip_on_cran()
+
   img_height <- 501
   img_width <- 502
 


### PR DESCRIPTION
Closes #348

FWIW, `deviceScaleFactor` was somewhat recently set to 1 https://github.com/rstudio/shinytest2/commit/563c24e38f96a91cf7bfa6e0d35264f9f1d7e435. That said, this commit message doesn't give much confidence that there was a real reason behind setting the default to 1 https://github.com/rstudio/shinytest2/pull/10/commits/34f733d9280e82a1cdbc29ceabbe82680c21a6ce
