### PR TITLE
Use `actions/v1` tag and update instructions

### DIFF
--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -40,13 +40,13 @@ jobs:
 
       # ## Suggested usage
       # - name: Test app
-      #   uses: rstudio/shinytest2/actions/test-app@v1
+      #   uses: rstudio/shinytest2/actions/test-app@actions/v1
       #   with:
       #     app-dir: |
       #       tests/testthat/apps/hello
 
       - name: Test app (main)
-        uses: rstudio/shinytest2/actions/test-app@v1
+        uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "tests/testthat/apps/window"
 

--- a/R/shinytest2-package.R
+++ b/R/shinytest2-package.R
@@ -1,2 +1,8 @@
 #' @useDynLib shinytest2, .registration = TRUE
 NULL
+
+release_bullets <- function() {
+  c(
+    "Is the `actions/test-app` sliding tag up-to-date? Check both `v1` and `actions/v1`."
+  )
+}

--- a/actions/test-app/README.Rmd
+++ b/actions/test-app/README.Rmd
@@ -103,7 +103,17 @@ Workflow contents:
 print_yaml("example-test-app-package.yaml")
 ```
 
+# Development
 
+The `test-app` action uses a sliding git tag that follows the pattern `actions/vX`, e.g. `actions/v1`. For historical reasons, we also support the `v1` tag, but future versions will only be available under the `actions/vX` tag.
+
+The `test-app` action release cycle is not dependent on the shinytest2 package cycle. When changes are made to the `test-app` action, you should force-update the current sliding tag version:
+
+```bash
+git tag -f v1            # update historical v1 tag
+git tag -f actions/v1    # update sliding tag
+git push --tags --force  # push tag to github
+```
 
 # License
 

--- a/actions/test-app/README.Rmd
+++ b/actions/test-app/README.Rmd
@@ -29,7 +29,7 @@ Inputs available:
 Typical (single app testing) GHA step usage:
 
 ``` yaml
-- uses: rstudio/shinytest2/actions/test-app@v1
+- uses: rstudio/shinytest2/actions/test-app@actions/v1
   with:
     app-dir: |
       dir/to/app
@@ -38,7 +38,7 @@ Typical (single app testing) GHA step usage:
 Multiple Apps can be tested by supplying multiple directories to `app-dir` separated by a newline:
 
 ```yaml
-- uses: rstudio/shinytest2/actions/test-app@v1
+- uses: rstudio/shinytest2/actions/test-app@actions/v1
   with:
     app-dir: |
       dir/to/app1

--- a/actions/test-app/README.md
+++ b/actions/test-app/README.md
@@ -23,7 +23,7 @@ Inputs available:
 Typical (single app testing) GHA step usage:
 
 ``` yaml
-- uses: rstudio/shinytest2/actions/test-app@v1
+- uses: rstudio/shinytest2/actions/test-app@actions/v1
   with:
     app-dir: |
       dir/to/app
@@ -33,7 +33,7 @@ Multiple Apps can be tested by supplying multiple directories to
 `app-dir` separated by a newline:
 
 ``` yaml
-- uses: rstudio/shinytest2/actions/test-app@v1
+- uses: rstudio/shinytest2/actions/test-app@actions/v1
   with:
     app-dir: |
       dir/to/app1
@@ -113,7 +113,7 @@ jobs:
           extra-packages:
             shinytest2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."
 ```
@@ -132,7 +132,7 @@ usethis::use_github_action(
 Workflow contents:
 
 ``` yaml
-# Workflow derived from https://github.com/rstudio/shinytest2/tree/main/actions/test-app/example-test-app-description.yaml
+# Workflow derived from https://github.com/rstudio/shinytest2/tree/main/actions/test-app/example-test-app-renv.yaml
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -171,7 +171,7 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."
 ```
@@ -238,9 +238,26 @@ jobs:
             local::.
             shinytest2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."
+```
+
+# Development
+
+The `test-app` action uses a sliding git tag that follows the pattern
+`actions/vX`, e.g. `actions/v1`. For historical reasons, we also support
+the `v1` tag, but future versions will only be available under the
+`actions/vX` tag.
+
+The `test-app` action release cycle is not dependent on the shinytest2
+package cycle. When changes are made to the `test-app` action, you
+should force-update the current sliding tag version:
+
+``` bash
+git tag -f v1            # update historical v1 tag
+git tag -f actions/v1    # update sliding tag
+git push --tags --force  # push tag to github
 ```
 
 # License

--- a/actions/test-app/example-test-app-description.yaml
+++ b/actions/test-app/example-test-app-description.yaml
@@ -40,6 +40,6 @@ jobs:
           extra-packages:
             shinytest2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."

--- a/actions/test-app/example-test-app-package.yaml
+++ b/actions/test-app/example-test-app-package.yaml
@@ -41,6 +41,6 @@ jobs:
             local::.
             shinytest2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."

--- a/actions/test-app/example-test-app-renv.yaml
+++ b/actions/test-app/example-test-app-renv.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/rstudio/shinytest2/tree/main/actions/test-app/example-test-app-description.yaml
+# Workflow derived from https://github.com/rstudio/shinytest2/tree/main/actions/test-app/example-test-app-renv.yaml
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:

--- a/actions/test-app/example-test-app-renv.yaml
+++ b/actions/test-app/example-test-app-renv.yaml
@@ -37,6 +37,6 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."

--- a/vignettes/use-ci.Rmd
+++ b/vignettes/use-ci.Rmd
@@ -113,7 +113,7 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."
           upload-snapshots: true
@@ -204,7 +204,7 @@ For a repository with this structure, the configuration is largely the same as a
 The `check-app.yaml` have all App dir locations supplied to `app-dir` using the multiline yaml string syntax.
 
 ```yaml
-      - uses: rstudio/shinytest2/actions/test-app@v1
+      - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: |
             01_hello

--- a/vignettes/use-ci.Rmd
+++ b/vignettes/use-ci.Rmd
@@ -124,7 +124,6 @@ jobs:
       - uses: rstudio/shinytest2/actions/test-app@actions/v1
         with:
           app-dir: "."
-          upload-snapshots: true
 ```
 
 You should change the `os` and `r` version to whatever operating system and R version is being used on the platform that your application will be deployed to.

--- a/vignettes/use-ci.Rmd
+++ b/vignettes/use-ci.Rmd
@@ -72,7 +72,15 @@ The files that you will need to add are described below.
 
 ### `check-app.yaml`
 
-This file contains information for GitHub Actions to build and test your application. It should look similar to this:
+This file contains information for GitHub Actions to build and test your application.
+You can easily set up this action in your repo with help from the [usethis package][usethis]:
+```r
+usethis::use_github_action(
+  url = "https://github.com/rstudio/shinytest2/raw/main/actions/test-app/example-test-app-renv.yaml",
+  save_as = "check-app.yaml"
+)
+```
+It should look similar to this:
 
 ```yml
 # Workflow derived from https://github.com/rstudio/shinytest2/tree/main/actions/test-app/example-test-app-description.yaml
@@ -273,3 +281,6 @@ This tells GitHub to install the `{shiny}` package from the `main` branch of htt
 # Example workflows
 
 To view example workflows and more description about the `test-app` GitHub Actions step, please see https://github.com/rstudio/shinytest2/tree/main/actions/test-app for more information examples.
+
+
+[usethis]: https://usethis.r-lib.org


### PR DESCRIPTION
For #359

We'll now use `actions/v1`, e.g. `actions/v2` etc, for the sliding version tag for the `test-app` action. This avoid the inevitable conflict that the R package might have a version 1.0 (although that tag would be `v1.0.0`).

This PR updates the example workflow YAML files and the `use-ci` vignette and adds developer documentation. I also added a release bullet to remind us to check the actions sliding tag when releasing a new package version.