### PR TITLE
fix(test-duplicate-ids): Check for duplicates instead of app start failure

### DIFF
--- a/tests/testthat/test-app-duplicate-ids.R
+++ b/tests/testthat/test-app-duplicate-ids.R
@@ -50,7 +50,7 @@ test_that("Duplicate input/output ids are found", {
 
 
 
-test_that("Duplicate output ids are found", {
+test_that("Duplicate custom output ids are found", {
 
   shiny_app <- shinyApp(
     ui = fluidPage(
@@ -74,7 +74,7 @@ test_that("Duplicate output ids are found", {
 })
 
 
-test_that("Duplicate input ids are found", {
+test_that("Duplicate shiny output ids are found", {
   shiny_app <- shinyApp(
     ui = fluidPage(
       # Duplicate output IDs causes failure to load application
@@ -87,8 +87,13 @@ test_that("Duplicate input ids are found", {
     }
   )
 
-  expect_error(
-    AppDriver$new(shiny_app, load_timeout = 2000),
-    "Shiny app did not become stable"
+  expect_warning(
+    app <- AppDriver$new(shiny_app, check_names = TRUE),
+    "html"
+  )
+
+  expect_failure(
+    app$expect_unique_names(),
+    "html"
   )
 })


### PR DESCRIPTION
As of shiny 1.8.1.1, Shiny apps no longer fail to start when an output ID is duplicated in the initial page load. For versions 1.8.1 and earlier, an error is thrown that halts shiny's initialization.

This PR changes the test to check for duplicate IDs with shinytest2 rather than testing behavior in shiny by testing that the app failed to load.