### PR TITLE
fix: Downgrade `mustExist` errors to a warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `{shinytest2}` now uses `{rlang}` and longer depends on `{ellipsis}` (@olivroy, #382).
 
+* `{shinytest2}` now warns rather than erroring when a potentially non-existent global variable is found in the server function, such as when column names are passed to `dplyr::select()` (thanks @matt-sd-watson @MichalLauer, #385).
+
 # shinytest2 0.3.1
 
 ## Breaking changes


### PR DESCRIPTION
Fixes #330

As described in the issue, `globals::globalsOf(mustExist = TRUE)` sometimes has false positives, for metaprogramming issues or when encountering a symbol that is defined later but that would be valid at runtime.

This PR downgrades `mustExist` errors to a warning message. Doing so requires two calls to `globals::globalsOf()`:

1. The first call uses `mustExist = FALSE`. Ignoring potentially non-existant globals might lead to other errors that are masked by the `mustExist = TRUE` case.

2. The second call uses `mustExist = TRUE`. If an error occurs at this step, then we downgrade "failed to locate" errors to a warning, otherwise we rethrow.