### PR TITLE
fix: default `transform=` to NULL, not itself

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # shinytest2 (development version)
 
+## Bug
+
+* Fixed a bug where `AppDriver$expect_values(transform=)` default value caused error to be thrown. (#413)
+
+
 # shinytest2 0.4.0
 
 ## Breaking changes

--- a/R/app-driver.R
+++ b/R/app-driver.R
@@ -574,7 +574,7 @@ AppDriver <- R6Class(
       export = missing_arg(),
       screenshot_args = missing_arg(),
       name = NULL,
-      transform = transform,
+      transform = NULL,
       cran = deprecated()
     ) {
       check_cran_deprecated(cran)

--- a/man/AppDriver.Rd
+++ b/man/AppDriver.Rd
@@ -1379,7 +1379,7 @@ Please see \href{https://rstudio.github.io/shinytest2/articles/robust.html}{Robu
   export = missing_arg(),
   screenshot_args = missing_arg(),
   name = NULL,
-  transform = transform,
+  transform = NULL,
   cran = deprecated()
 )}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Fixes #412 

Caused by https://github.com/rstudio/shinytest2/pull/403/files#diff-0d1ce7fc81fe906c4a0aecdbcc5ef264a6dd8e6a9d5828bfa33c30000695d3d0R577