### PR TITLE
fix: Skip test-not-testing.R test on CRAN

### DIFF
--- a/tests/testthat/test-not-testing.R
+++ b/tests/testthat/test-not-testing.R
@@ -1,6 +1,7 @@
 require("shiny", quietly = TRUE, character.only = TRUE)
 
 test_that("Running an app not in testing mode has 404 handled when getting values", {
+  skip_on_cran()
 
   app_bg <- callr::r_bg(
     function() {


### PR DESCRIPTION
## Summary

Fixes #440 by adding `skip_on_cran()` to the beginning of the failing test in `test-not-testing.R`.

## Problem

The test "Running an app not in testing mode has 404 handled when getting values" was failing on CRAN with:
```
Expected `!is.null(app_url)` to be TRUE.
```

The failure occurred because:
- Chrome is not available on CRAN servers
- The test was trying to start a background Shiny app process
- The test failed at line 31 (checking `app_url`) before reaching the AppDriver initialization

## Solution

Added `skip_on_cran()` at the beginning of the test to ensure it's completely skipped on CRAN before any background processes are started. This follows CRAN's requirement that external programs should be used conditionally and is consistent with the existing pattern used throughout the test suite.

## Testing

The change adds a single line that skips the entire test on CRAN. The test will continue to run in all other environments (local development, CI) where Chrome is available.

## Checklist

- [x] Addresses CRAN check failure before the March 2, 2026 deadline
- [x] Follows existing skip_on_cran() patterns in the codebase
- [x] Minimal change with no impact on non-CRAN testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)