### PR TITLE
fix: Wait for app port to bind before navigating (#448)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
     diffobj,
     ggplot2,
     golem,
+    httpuv,
     knitr,
     plotly,
     png,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Bug fixes and minor improvements
 
+* `AppDriver$new()` no longer intermittently aborts during initialization with
+  "Shiny app did not become stable" when the app's port is slow to bind. Shiny
+  prints its "Listening on ..." line before it binds the listening socket, so on
+  a slow or loaded host the initial navigation could reach a not-yet-bound port
+  and land on the browser's error page; the error-page recovery navigation then
+  raced the readiness and idle checks. `AppDriver$new()` now waits for the port
+  to accept a connection before navigating (@nbenn, #448).
+
 * `$get_download()` and `$expect_download()` now correctly construct the
   download URL when the app URL contains query parameters. Previously,
   query parameters were concatenated into the download path, causing an

--- a/R/app-driver-start.R
+++ b/R/app-driver-start.R
@@ -271,5 +271,43 @@ app_start_shiny <- function(
   url <- sub(".*(https?://.*)", "\\1", line)
   private$shiny_url$set(url)
 
+  # shiny prints the "Listening on ..." line above *before* it binds the
+  # listening socket (rstudio/shiny#4400), so on a slow or loaded host the port
+  # may not be accepting connections yet. Navigating then lands on the browser's
+  # error page, and the later recovery navigation (once the app binds) races
+  # initialization's readiness and idle checks into an opaque "did not become
+  # stable" abort (rstudio/shinytest2#448). Wait for the port to accept a
+  # connection before returning so the caller navigates against a bound socket.
+  app_wait_for_serving(url, timeout = load_timeout)
+
   invisible(self)
+}
+
+# Poll `url`'s port until it accepts a connection (or `timeout` ms elapse), so
+# the caller can navigate against a bound socket rather than the error page the
+# browser shows for a not-yet-bound port. Returns invisibly whether the port
+# came up. `pingr::is_up()` is the same reachability check `app_httr2_get()`
+# already uses.
+app_wait_for_serving <- function(url, timeout = 10000) {
+  pieces <- httr2::url_parse(url)
+  # Add in port information if it's missing, matching `app_httr2_get()`.
+  # https://github.com/rstudio/shinytest2/issues/158
+  if (is.null(pieces$port)) {
+    pieces$port <- switch(pieces$scheme, "http" = 80, "https" = 443)
+  }
+
+  deadline <- Sys.time() + timeout / 1000
+  repeat {
+    if (isTRUE(pingr::is_up(
+      pieces$hostname,
+      pieces$port,
+      check_online = FALSE
+    ))) {
+      return(invisible(TRUE))
+    }
+    if (Sys.time() >= deadline) {
+      return(invisible(FALSE))
+    }
+    Sys.sleep(0.05)
+  }
 }

--- a/tests/testthat/test-app-start.R
+++ b/tests/testthat/test-app-start.R
@@ -1,0 +1,21 @@
+# https://github.com/rstudio/shinytest2/issues/448
+test_that("app_wait_for_serving() returns FALSE for an unbound port", {
+  port <- httpuv::randomPort()
+  url <- sprintf("http://127.0.0.1:%s/", port)
+
+  # Nothing is listening on `port`, so the wait should give up and report the
+  # port never came up (rather than blocking or erroring).
+  start <- Sys.time()
+  expect_false(app_wait_for_serving(url, timeout = 200))
+  # Should honor the timeout rather than hang indefinitely.
+  expect_lt(as.numeric(Sys.time() - start, units = "secs"), 5)
+})
+
+test_that("app_wait_for_serving() returns TRUE once the port accepts connections", {
+  port <- httpuv::randomPort()
+  server <- httpuv::startServer("127.0.0.1", port, list())
+  withr::defer(server$stop())
+
+  url <- sprintf("http://127.0.0.1:%s/", port)
+  expect_true(app_wait_for_serving(url, timeout = 5000))
+})

--- a/tests/testthat/test-app-start.R
+++ b/tests/testthat/test-app-start.R
@@ -1,5 +1,7 @@
 # https://github.com/rstudio/shinytest2/issues/448
 test_that("app_wait_for_serving() returns FALSE for an unbound port", {
+  skip_if_not_installed("httpuv")
+
   port <- httpuv::randomPort()
   url <- sprintf("http://127.0.0.1:%s/", port)
 
@@ -12,6 +14,8 @@ test_that("app_wait_for_serving() returns FALSE for an unbound port", {
 })
 
 test_that("app_wait_for_serving() returns TRUE once the port accepts connections", {
+  skip_if_not_installed("httpuv")
+
   port <- httpuv::randomPort()
   server <- httpuv::startServer("127.0.0.1", port, list())
   withr::defer(server$stop())


### PR DESCRIPTION
Fixes #448

## Summary
An intermittent `AppDriver$new()` failure — `Shiny app did not become stable` — traces back to a startup race: Shiny prints its `Listening on http://…` line *one statement before* it binds the listening socket (rstudio/shiny#4400). `app_start_shiny()` parsed the URL from that stderr line and let initialization navigate the browser immediately, so on a slow or loaded host the browser could reach a not-yet-bound port, land on Chrome's error page, and when the app finally bound, the error-page recovery navigation raced the readiness/idle checks into the opaque abort (which fires well before `load_timeout`).

This adds an `app_wait_for_serving()` helper that polls the port with `pingr::is_up()` — the same reachability check `app_httr2_get()` already uses — until it accepts a connection or `load_timeout` elapses, then returns. Initialization therefore navigates against a bound socket. If the port never comes up in time, the helper returns quietly and startup proceeds as before (graceful fallback). This mirrors the approach proposed by @nbenn in the issue.

## Verification
Using the issue's deterministic reproducer (tracing `startServer` to sleep 5s before bind): **without** the fix it aborts in ~6s with `did not become stable … Caused by error in app_wait_for_idle()`; **with** the fix the app becomes stable in ~8s. New unit tests in `tests/testthat/test-app-start.R` cover both the unbound-port (returns `FALSE`, honors timeout) and bound-port (returns `TRUE`) cases.